### PR TITLE
line-height from .status-icon to .status-icon > i.

### DIFF
--- a/less/chart.less
+++ b/less/chart.less
@@ -359,13 +359,13 @@
             color: white;
             width: 22px;
             height: 22px;
-            line-height: 22px;
             position: relative;
             top: -1px;
             .border-radius(100px);
 
             > i {
                 font-size: 10px;
+                line-height: 22px;
             }
         }
 


### PR DESCRIPTION
Fix for Firefox 52.0.
Tested on firefox 52.0, chrome 57.0.2987.98, IE 11.576.14393.0, Edge 38.14393.0.0.

Moving the line-height from .status-icon to .status-icon > i re-centers the icon in Firefox. Icon looks okay in Chrome, IE and Edge.

Untested in Safari.